### PR TITLE
Change average splits per day graph to use timestack for x axis

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,8 @@
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&display=swap" rel="stylesheet">
 
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/luxon@3.4.4/build/global/luxon.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-scale-timestack/dist/chartjs-scale-timestack.min.js"></script>
 </head>
 <body>
     <div class="header">

--- a/js/graphs.js
+++ b/js/graphs.js
@@ -237,7 +237,7 @@ export function buildAvgEntryChart(runs) {
 
 function toUnixTimestamp(date) {
     // surely mr fors will take less than 1 year to get the record
-    return new Date(`${date} ${new Date().getFullYear()} 00:00:00 GMT+0`).getTime();
+    return new Date(`${date} ${new Date().getFullYear()}`).getTime();
 }
 
 function timestackData(data, key)

--- a/js/graphs.js
+++ b/js/graphs.js
@@ -125,11 +125,11 @@ export function buildAvgEntryChart(runs) {
     for (let r = 0; r < runs.length; r++) {
         const run = runs[r];
 
-        if (run.nether) pushOrCreate(netherDays, run.date, run.nether);
-        if (run.bastion || run.fort) pushOrCreate(struct1Days, run.date, !run.bastion ? run.fort : !run.fort ? run.bastion : Math.min(run.fort, run.bastion));
-        if (run.bastion && run.fort) pushOrCreate(struct2Days, run.date, Math.max(run.fort, run.bastion));
-        if (run.blind)  pushOrCreate(blindDays, run.date, run.blind);
-        if (run.stronghold) pushOrCreate(strongholdDays, run.date, run.stronghold);
+        if (run.nether) pushOrCreate(netherDays, toUnixTimestamp(run.date), run.nether);
+        if (run.bastion || run.fort) pushOrCreate(struct1Days, toUnixTimestamp(run.date), !run.bastion ? run.fort : !run.fort ? run.bastion : Math.min(run.fort, run.bastion));
+        if (run.bastion && run.fort) pushOrCreate(struct2Days, toUnixTimestamp(run.date), Math.max(run.fort, run.bastion));
+        if (run.blind)  pushOrCreate(blindDays, toUnixTimestamp(run.date), run.blind);
+        if (run.stronghold) pushOrCreate(strongholdDays, toUnixTimestamp(run.date), run.stronghold);
     }
 
     // Average the times for each day
@@ -149,7 +149,7 @@ export function buildAvgEntryChart(runs) {
             datasets: [
                 {
                     label: "Nether Entry",
-                    data: dates.map(d => netherDays[d]),
+                    data: dates.map(d => timestackData(netherDays, d)),
                     showLine: true,
                     fill: "start",
                     pointBackgroundColor: C_NETHER,
@@ -158,7 +158,7 @@ export function buildAvgEntryChart(runs) {
                 },
                 {
                     label: "Struct 1 Entry",
-                    data: dates.map(d => struct1Days[d]),
+                    data: dates.map(d => timestackData(struct1Days, d)),
                     showLine: true,
                     fill: "start",
                     pointBackgroundColor: C_BASTION,
@@ -167,7 +167,7 @@ export function buildAvgEntryChart(runs) {
                 },
                 {
                     label: "Struct 2 Entry",
-                    data: dates.map(d => struct2Days[d]),
+                    data: dates.map(d => timestackData(struct2Days, d)),
                     showLine: true,
                     fill: "start",
                     pointBackgroundColor: C_FORT,
@@ -176,7 +176,7 @@ export function buildAvgEntryChart(runs) {
                 },
                 {
                     label: "Blind",
-                    data: dates.map(d => blindDays[d]),
+                    data: dates.map(d => timestackData(blindDays, d)),
                     showLine: true,
                     fill: "start",
                     pointBackgroundColor: C_BLIND,
@@ -185,7 +185,7 @@ export function buildAvgEntryChart(runs) {
                 },
                 {
                     label: "Stronghold Entry",
-                    data: dates.map(d => strongholdDays[d]),
+                    data: dates.map(d => timestackData(strongholdDays, d)),
                     showLine: true,
                     fill: "start",
                     pointBackgroundColor: C_STRONGHOLD,
@@ -199,9 +199,20 @@ export function buildAvgEntryChart(runs) {
             maintainAspectRatio: false,
             scales: {
                 x: {
-                    type: "category",
-                    parsing: false,
-                    title: {display: true, text: "Day #"}
+                    type: "timestack",
+                    title: { display: true, text: "Date" },
+                    timestack: {
+                        format_style: {
+                            second: undefined,
+                            minute: undefined,
+                            hour: undefined
+                        },
+                        tooltip_format: {
+                            second: undefined,
+                            minute: undefined,
+                            hour: undefined
+                        }
+                    }
                 },
                 y: {
                     type: "linear",
@@ -222,4 +233,14 @@ export function buildAvgEntryChart(runs) {
             },
         },
     });
+}
+
+function toUnixTimestamp(date) {
+    // surely mr fors will take less than 1 year to get the record
+    return new Date(`${date} ${new Date().getFullYear()} 00:00:00 GMT+0`).getTime();
+}
+
+function timestackData(data, key)
+{
+    return { x: +key, y: data[key] };
 }


### PR DESCRIPTION
Hi mr Bleach, here's a small pull to switch one of the graphs to use [timestack scale](https://github.com/jkmnt/chartjs-scale-timestack) I like a lot, and use in one of my lidl dashboards.

It's not really useful right now, but will start to look better as the number of tracked days inevitably grow bigger and bigger.

Here's how it looks with the current data (note the X axis):
<img width="725" height="395" alt="image" src="https://github.com/user-attachments/assets/0a9ffe07-6bc7-4828-9e7b-af22fe8e8333" />
Looks better that default angled ticks that duplicate months, at least for me.

I'm not really a JS guy, so I just quicky slapped together something that works (until the end of 2026, surely mr Fors will have the record by then Clueless) -- this is actually the limitation of the data using timestamps like "Jan 29" without the year.

I also took the liberty to change the X axis title, "Day #" to "Date", which it actually is.

Feel free to suggest and/or implement changes.

Another thing I'd like to point out is that the stacked X axis makes the graph itself slightly smaller vertically so some tinkering is required to make them even again, if that's critical:
<img width="325" height="393" alt="image" src="https://github.com/user-attachments/assets/8ce94536-69cb-4fcb-b1d4-82698cb04c74" />

